### PR TITLE
投稿するメッセージ内の質問を毎日ランダムにし、その回答画面のURLをはる

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -7,7 +7,11 @@ class AnswersController < ApplicationController
 
   def new
     @answer = Answer.new
-    @question = Question.find(Question.pluck(:id).sample)
+    if params[:question]
+      @question = Question.find(params[:question])
+    else
+      @question = Question.find(Question.pluck(:id).sample)
+    end
   end
 
   def show

--- a/app/models/discord_message.rb
+++ b/app/models/discord_message.rb
@@ -4,8 +4,8 @@ class DiscordMessage
   MESSAGE_COUNTS = 3
 
   def send
-    if Answer.count >= MESSAGE_COUNTS
-      answers = Answer.find(Answer.pluck(:id).sample(MESSAGE_COUNTS))
+    if Answer.where(posted: false).count >= MESSAGE_COUNTS
+      answers = Answer.find(Answer.where(posted: false).pluck(:id).sample(MESSAGE_COUNTS))
       post_message(first_message)
       answers.each do |answer|
         answer.update(posted: true) if post_message(answers_message(answer))

--- a/app/models/discord_message.rb
+++ b/app/models/discord_message.rb
@@ -83,9 +83,11 @@ class DiscordMessage
 
   def daily_embet
     question = Question.find(Question.pluck(:id).sample)
+    routes = Rails.application.routes.url_helpers
+    url = routes.url_for(host: "127.0.0.1:3000", controller: :answers, action: :new, question: question.id ,only_path: false)
     {
       title: question.body,
-      description: '質問に回答するには[ここ](http://example.com)にアクセスしてね。過去に投稿されたみんなの回答も見れるよ！'
+      description: "質問に回答するには[ここ](#{url})にアクセスしてね。過去に投稿されたみんなの回答も見れるよ！"
     }
   end
 end


### PR DESCRIPTION
issue #10 

毎日送るメッセージに、この質問に答えてね〜と日毎にランダムに質問を表示する。
のはやっていたんだけど、今回は
その質問に答えられる画面のURLを作ってそこに飛べるようにしました。
パラメーターで質問IDを持たせて、パラメーターがあればその質問、なければランダムな質問を表示するようにしました。

ついでに送信するメッセージのなかに投稿済みのものも含まれてしまっていたので修正しました。
