### PR TITLE
回答がDiscordに投稿された時間をレコードする

### DIFF
--- a/app/assets/stylesheets/partials/_list.scss
+++ b/app/assets/stylesheets/partials/_list.scss
@@ -45,12 +45,16 @@
   }
 
   &__row {
-    color: $color4;
+    color: lighten($color4, 15%);
     font-size: 0.8rem;
     line-height: 1.4;
 
+    &:first-child {
+      margin-bottom: 8px;
+    }
+
     &:not(:first-child) {
-      margin-top: 6px;
+      margin-top: 4px;
     }
   }
 }

--- a/app/assets/stylesheets/partials/_list.scss
+++ b/app/assets/stylesheets/partials/_list.scss
@@ -16,10 +16,6 @@
     align-items: center;
   }
 
-  &.is-posted {
-    
-  }
-
   &__user {
     display: flex;
     align-items: center;
@@ -101,8 +97,26 @@
   position: absolute;
   bottom: 12px;
   right: 12px;
-  padding: 4px 8px;
   border-radius: 4px;
   border: 1px solid $color2;
   color: $color2;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  &__text {
+    border-bottom: 1px solid $color2;
+    padding: 3px;
+    font-size: 0.8rem;
+  }
+  &__time {
+    font-size: 0.7rem;
+    padding: 3px;
+  }
+}
+
+@media screen and (max-width:768px) {
+  .stamp {
+    bottom: 8px;
+    right: 8px;
+  }
 }

--- a/app/assets/stylesheets/partials/_page.scss
+++ b/app/assets/stylesheets/partials/_page.scss
@@ -23,12 +23,22 @@
 
 .page-header-meta {
   display: flex;
+  flex-wrap: wrap;
   margin-bottom: 10px;
 
   &__item {
     margin-right: 10px;
-    color: $color5;
+    color: lighten($color4, 18%);
     font-size: 0.9rem;
+    line-height: 1.4;
+
+    & span {
+      background: lighten($color4, 18%);
+      color: $white;
+      padding: 4px 8px;
+      border-radius: 8px;
+      font-size: 0.7rem;
+    }
   }
 }
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -2,7 +2,7 @@
 
 class AnswersController < ApplicationController
   def index
-    @answers = Answer.where(posted: true).order(created_at: :desc).page(params[:page])
+    @answers = Answer.where(posted: true).order(posted_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -15,7 +15,8 @@ class AnswersController < ApplicationController
   end
 
   def show
-    @answer = Answer.find(params[:id])
+    @answer = Answer.where(posted: true)
+                    .or(Answer.where(user_id: current_user.id)).find(params[:id])
   end
 
   def edit

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module AnswersHelper
-  def posted_or_not(answer)
-    answer.posted ? 'is-posted' : ''
-  end
-end

--- a/app/models/discord_message.rb
+++ b/app/models/discord_message.rb
@@ -8,7 +8,7 @@ class DiscordMessage
       answers = Answer.find(Answer.where(posted: false).pluck(:id).sample(MESSAGE_COUNTS))
       post_message(first_message)
       answers.each do |answer|
-        answer.update(posted: true) if post_message(answers_message(answer))
+        answer.update(posted: true, posted_at: Time.current) if post_message(answers_message(answer))
       end
       post_message(end_message)
     else

--- a/app/views/answers/index.html.slim
+++ b/app/views/answers/index.html.slim
@@ -21,10 +21,15 @@
                 = l answer.user.created_at, format: :date_only
           .list-item__row
             = truncate(answer.body, length: 80)
-- else
+- elsif params[:keyword]
   .empty-message
     / i.fas.fa-poo
     i.far.fa-frown
     p
       | '#{params[:keyword]}'に一致する情報は見つかりませんでした。
+-else
+  .empty-message
+    i.far.fa-sad-tear
+    p
+      | まだ回答はありません。
 = paginate @answers

--- a/app/views/answers/index.html.slim
+++ b/app/views/answers/index.html.slim
@@ -18,7 +18,7 @@
               .list-item-meta__item
                 | #{answer.user.name}##{answer.user.discriminator}
               .list-item-meta__item
-                = l answer.user.created_at, format: :date_only
+                = l answer.user.created_at.to_date, format: :long
           .list-item__row
             = truncate(answer.body, length: 80)
 - elsif params[:keyword]

--- a/app/views/answers/show.html.slim
+++ b/app/views/answers/show.html.slim
@@ -13,7 +13,15 @@
           .page-header-meta__item
             | #{@answer.user.name}##{@answer.user.discriminator}
           .page-header-meta__item
-            = l @answer.user.created_at, format: :date_only
+            | 作成日: 
+            = l @answer.created_at.to_date, format: :long
+          - if @answer.posted?
+            .page-header-meta__item
+              | 投稿日: 
+              = l @answer.posted_at.to_date, format: :long
+          - else
+            .page-header-meta__item
+              span 未投稿
       .page-header__row
         h2.page-header-title
           = @answer.question.body

--- a/app/views/users/answers/index.html.slim
+++ b/app/views/users/answers/index.html.slim
@@ -1,22 +1,27 @@
 .page-title
   h1.page-title__text 自分の回答一覧
-
-.list-container
-  - @answers.each do |answer|
-    div class="list-item #{posted_or_not(answer)}"
-      = image_tag answer.user.avatar_url, class: 'list-item__icon'
-      .list-item__rows
-        .list-item__row
-          = link_to answer.question.body, answer_path(answer), class: 'list-item-title #{posted_or_not(answer)}"'
-        .list-item__row
-          .list-item-meta
-            .list-item-meta__item
-              | #{answer.user.name}##{answer.user.discriminator}
-            .list-item-meta__item
-              = l answer.user.created_at, format: :date_only
-        .list-item__row
-          = truncate(answer.body, length: 80)
-      - if answer.posted?
-        .stamp
-          | 投稿済み
+- if @answers.size.positive?
+  .list-container
+    - @answers.each do |answer|
+      div class="list-item #{posted_or_not(answer)}"
+        = image_tag answer.user.avatar_url, class: 'list-item__icon'
+        .list-item__rows
+          .list-item__row
+            = link_to answer.question.body, answer_path(answer), class: 'list-item-title #{posted_or_not(answer)}"'
+          .list-item__row
+            .list-item-meta
+              .list-item-meta__item
+                | #{answer.user.name}##{answer.user.discriminator}
+              .list-item-meta__item
+                = l answer.user.created_at, format: :date_only
+          .list-item__row
+            = truncate(answer.body, length: 80)
+        - if answer.posted?
+          .stamp
+            | 投稿済み
+- else
+  .empty-message
+    i.far.fa-sad-tear
+    p
+      | まだ回答はありません。
 = paginate @answers

--- a/app/views/users/answers/index.html.slim
+++ b/app/views/users/answers/index.html.slim
@@ -3,7 +3,7 @@
 - if @answers.size.positive?
   .list-container
     - @answers.each do |answer|
-      div class="list-item #{posted_or_not(answer)}"
+      div class="list-item"
         = image_tag answer.user.avatar_url, class: 'list-item__icon'
         .list-item__rows
           .list-item__row
@@ -18,7 +18,9 @@
             = truncate(answer.body, length: 80)
         - if answer.posted?
           .stamp
-            | 投稿済み
+            span.stamp__text 投稿済み
+            time.stamp__time
+              = l answer.posted_at.to_date, format: :short
 - else
   .empty-message
     i.far.fa-sad-tear

--- a/app/views/users/answers/index.html.slim
+++ b/app/views/users/answers/index.html.slim
@@ -13,7 +13,7 @@
               .list-item-meta__item
                 | #{answer.user.name}##{answer.user.discriminator}
               .list-item-meta__item
-                = l answer.user.created_at, format: :date_only
+                = l answer.user.created_at.to_date, format: :long
           .list-item__row
             = truncate(answer.body, length: 80)
         - if answer.posted?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   date:
     formats:
       default: "%Y年%m月%d日"
+      long: "%Y年%m月%d日(%a)"
       ym_jp: "%Y年%m月"
       ym: "%Y%m"
       ymd_hy: "%Y-%m-%d"
@@ -14,7 +15,6 @@ ja:
       default: "%Y年%m月%d日(%a) %H:%M"
       short: "%Y/%m/%d %H:%M"
       time_only: "%H:%M"
-      date_only: "%Y年%m月%d日(%a)"
       date_and_time: "%m月%d日%H:%M"
   activerecord:
     models:

--- a/db/migrate/20210612033837_add_posted_at_to_answers.rb
+++ b/db/migrate/20210612033837_add_posted_at_to_answers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPostedAtToAnswers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :answers, :posted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_130300) do
+ActiveRecord::Schema.define(version: 2021_06_12_033837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_130300) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "posted", default: false, null: false
+    t.datetime "posted_at"
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["user_id"], name: "index_answers_on_user_id"
   end


### PR DESCRIPTION
issue #45

回答がDiscordに投稿された時間をDBに保存するようにしました。
投稿日時を必要な画面に表示されるようにしました。
みんなの回答は投稿された順に並べ替えました。
showの画面で他の人の未投稿のものがurlで見れてしまうようだったので直しました。