### PR TITLE
サーバーからいなくなったユーザーを自動で削除

### DIFF
--- a/app/models/discord_remove_member.rb
+++ b/app/models/discord_remove_member.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DiscordRemoveMember
+  def initialize(bot)
+    @bot = bot
+  end
+
+  def run
+    # banや脱退などサーバーからメンバーがいなくなったらそのユーザーを消去
+    @bot.member_leave do |event|
+      user_id = event.user.id
+      user = User.find_by(uid: user_id)
+      user&.destroy
+    end
+  end
+end

--- a/lib/tasks/discord_bot.rake
+++ b/lib/tasks/discord_bot.rake
@@ -4,6 +4,7 @@ namespace :discord_bot do
   desc 'start discord bot'
   task start: :environment do
     bot = Discordrb::Bot.new token: ENV['DISCORD_BOT_TOKEN']
+    DiscordRemoveMember.new(bot).run
     bot.run
   end
 


### PR DESCRIPTION
issue #37 

BANリストを取得するか、リアルタイムでサーバーからいなくなったメンバーをテーブルから削除するかどっちの実装にしようか、という感じだったのですが、
とりあえず後者で実装しました。