### PR TITLE
サーバーのオーナーは管理者権限の編集をできないようにする

### DIFF
--- a/app/assets/stylesheets/partials/_btn.scss
+++ b/app/assets/stylesheets/partials/_btn.scss
@@ -26,6 +26,16 @@
   background-color: $color1;
 }
 
+.btn-owner {
+  background-color: $white;
+  border: 1px solid $color2;
+  color: $color2;
+  &:hover {
+    opacity: 1;
+    color: $color2;
+  }
+}
+
 .list-item__links {
   & .btn {
     width: 70px;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
       user.avatar = avatar
       user.discriminator = discriminator
       user.admin = true if owner_id == uid
+      user.owner = true if owner_id == uid
     end
   end
 

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -15,7 +15,10 @@
             = user.name
             span.list-item__discriminator
               | ##{user.discriminator}
-        - if user.admin?
+        -if user.owner?
+          .btn.btn-admin-user.btn-owner
+            | 管理人
+        - elsif user.admin?
           = link_to '管理者解除', admin_user_path(user), method: :patch, data: { confirm: '本当によろしいですか？' }, class: 'btn btn-admin-user'
         - else
           = link_to '管理者にする', admin_user_path(user), method: :patch, data: { confirm: '本当によろしいですか？' }, class: 'btn btn-admin-user btn-user'

--- a/db/migrate/20210617063340_add_owner_to_users.rb
+++ b/db/migrate/20210617063340_add_owner_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOwnerToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :owner, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_12_033837) do
+ActiveRecord::Schema.define(version: 2021_06_17_063340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2021_06_12_033837) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "admin", default: false, null: false
+    t.boolean "owner", default: false, null: false
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 


### PR DESCRIPTION
issue #53

ownerカラムを追加して、サーバーのオーナーは管理者権限の変種をできないようにしました。